### PR TITLE
Fixed R2-6 release year from 2017 to 2018

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -19,7 +19,7 @@ files respectively, in the configure/ directory of the appropriate release of th
 Release Notes
 =============
 
-R2-6 (29-January-2017)
+R2-6 (29-January-2018)
 ----
 * Removed the SerialNumber, FirmwareVersion, and SoftwareVersion parameters and records,
   since the equivalents are now in ADDriver.h and ADBase.template.


### PR DESCRIPTION
Minor typo, fixing release year for R2-6.  Not sure if it's referenced elsewhere as well.