### PR TITLE
PixelFormatValues corrected to unsigned int

### DIFF
--- a/pointGreyApp/src/pointGrey.cpp
+++ b/pointGreyApp/src/pointGrey.cpp
@@ -235,7 +235,7 @@ static const char *convertPixelFormatStrings[NUM_CONVERT_PIXEL_FORMATS] = {
     "RGB16",
 };
 
-static const int convertPixelFormatValues[NUM_CONVERT_PIXEL_FORMATS] = {
+static const unsigned int convertPixelFormatValues[NUM_CONVERT_PIXEL_FORMATS] = {
     0,
     PIXEL_FORMAT_MONO8,
     PIXEL_FORMAT_RAW16,


### PR DESCRIPTION
This resolves compilation error when using gcc 6.3.0,
Debian 9
base-7.0.1.1
make-4.1