### PR TITLE
 added Resend Packet Enable feature

### DIFF
--- a/pointGreyApp/Db/pointGreyGigEProperty.template
+++ b/pointGreyApp/Db/pointGreyGigEProperty.template
@@ -51,3 +51,20 @@ record(ao, "$(P)$(R)$(PROPERTY)ValHopr") {
   field(OMSL, "closed_loop")
   field(OUT, "$(P)$(R)$(PROPERTY)Val.HOPR NPP NMS")
 }
+
+#Packets resend enable
+record(bo,"$(P)$(R)ResendEnable"){
+  field(PINI,"YES")
+  field(DTYP, "asynInt32")
+  field(ZNAM, "Disable")
+  field(ONAM, "Enable")
+  field(OUT, "@asyn($(PORT) 0)PG_PACKET_RESEND_ENABLE")
+}
+
+record(bi, "$(P)$(R)ResendEnable_RBV"){
+  field(SCAN, "I/O Intr")
+  field(DTYP, "asynInt32")
+  field(ZNAM, "Disable")
+  field(ONAM, "Enable")
+  field(INP, "@asyn($(PORT) 0)PG_PACKET_RESEND_ENABLE")
+}

--- a/pointGreyApp/src/pointGrey.cpp
+++ b/pointGreyApp/src/pointGrey.cpp
@@ -86,6 +86,7 @@ static const char *driverName = "pointGrey";
 #define PGMaxPacketSizeString         "PG_MAX_PACKET_SIZE"
 #define PGPacketDelayString           "PG_PACKET_DELAY"
 #define PGPacketDelayActualString     "PG_PACKET_DELAY_ACTUAL"
+#define PGPacketResendEnableString	  "PG_PACKET_RESEND_ENABLE"
 #define PGBandwidthString             "PG_BANDWIDTH"
 #define PGTimeStampModeString         "PG_TIME_STAMP_MODE"
 #define PGCorruptFramesString         "PG_CORRUPT_FRAMES"
@@ -373,6 +374,7 @@ protected:
     int PGMaxPacketSize;          /** Maximum size of data packets from camera        (int32 write/read) */
     int PGPacketDelay;            /** Packet delay in usec from camera, GigE only     (int32 write/read) */
     int PGPacketDelayActual;      /** Packet delay in usec from camera, GigE only     (int32 read) */
+    int PGPacketResendEnable;		 /** Packet resend enable, GigE only					  (int32 read/write) */
     int PGBandwidth;              /** Bandwidth in MB/s                               (float64 read) */
     int PGTimeStampMode;          /** Time stamp mode (PGTimeStamp_t)                 (int32 write/read) */
     int PGCorruptFrames;          /** Number of corrupt frames                        (int32 read) */
@@ -409,6 +411,7 @@ private:
     asynStatus createDynamicEnums();
     asynStatus getAllProperties();
     asynStatus getAllGigEProperties();
+    asynStatus getGigEConfigParams();
     int getPixelFormatIndex(PixelFormat pixelFormat);
     asynStatus setTrigger();
     asynStatus softwareTrigger();
@@ -435,6 +438,7 @@ private:
     Property              *allProperties_[NUM_PROPERTIES];
     PropertyInfo          *allPropInfos_ [NUM_PROPERTIES];
     GigEProperty          *allGigEProperties_[NUM_GIGE_PROPERTIES];
+    GigEConfig				  *pGigEConfig_;
     int numValidVideoModes_;
     int numValidFormat7Modes_;
     int numValidBinningModes_;
@@ -578,6 +582,7 @@ pointGrey::pointGrey(const char *portName, int cameraId, int traceMask, int memo
     createParam(PGMaxPacketSizeString,          asynParamInt32,   &PGMaxPacketSize);
     createParam(PGPacketDelayString,            asynParamInt32,   &PGPacketDelay);
     createParam(PGPacketDelayActualString,      asynParamInt32,   &PGPacketDelayActual);
+    createParam(PGPacketResendEnableString,		asynParamInt32, 	&PGPacketResendEnable);
     createParam(PGBandwidthString,              asynParamFloat64, &PGBandwidth);
     createParam(PGTimeStampModeString,          asynParamInt32,   &PGTimeStampMode);
     createParam(PGCorruptFramesString,          asynParamInt32,   &PGCorruptFrames);
@@ -637,6 +642,9 @@ pointGrey::pointGrey(const char *portName, int cameraId, int traceMask, int memo
         allGigEProperties_[i]->propType = (GigEPropertyType) i;
     }
     getAllGigEProperties();
+    
+    pGigEConfig_=new GigEConfig();
+    getGigEConfigParams();
 
     createStaticEnums();
     createDynamicEnums();
@@ -666,8 +674,23 @@ pointGrey::pointGrey(const char *portName, int cameraId, int traceMask, int memo
         setIntegerParam(PGPacketDelay, DEFAULT_PACKET_DELAY);
         setGigEPropertyValue(PACKET_SIZE, packetSize);
         setGigEPropertyValue(PACKET_DELAY, DEFAULT_PACKET_DELAY);
-    }
-
+    
+    // Get and set Enable Packet resend property 
+	     if(pGigEConfig_){
+				error = pGigECamera_->GetGigEConfig(pGigEConfig_);
+				if(checkError(error, functionName, "GetGigEConfig")){
+				//There should not be an error getting the config parmas, but in case set some defaults
+				pGigEConfig_ -> enablePacketResend= true;
+				pGigEConfig_ -> registerTimeoutRetries = 3;
+				pGigEConfig_ -> registerTimeout = 20000;
+				}
+		  asynPrint(pasynUserSelf, ASYN_TRACE_WARNING,
+				"%s::%s called GetGigEConfig, pGigEConfig_=%p, packetResendEnable=%d\n",
+				driverName, functionName, pGigEConfig_, pGigEConfig_->enablePacketResend);
+		  setIntegerParam(PGPacketResendEnable, pGigEConfig_->enablePacketResend);	
+	    }
+	}
+	
     startEventId_ = epicsEventCreate(epicsEventEmpty);
 
     /* launch image read task */
@@ -1187,7 +1210,8 @@ asynStatus pointGrey::writeInt32( asynUser *pasynUser, epicsInt32 value)
                 (function == PGPixelFormat) ||
                 (function == PGBinningMode) ||
                 (function == PGPacketSize)  ||
-                (function == PGPacketDelay)) {
+                (function == PGPacketDelay) ||
+                (function == PGPacketResendEnable))	 {
         status = setImageParams();
 
     } else if (function == PGPropertyValue) {
@@ -1955,6 +1979,17 @@ asynStatus pointGrey::setGigEImageParams()
     if (packetDelay > maxPacketDelay) packetDelay = maxPacketDelay;
     setGigEPropertyValue(PACKET_DELAY, packetDelay);
 
+	 //Set resend Enable, assume gigEConfig structure reflects camera hardware settings
+	 int enablePacketResend;
+	 getIntegerParam(PGPacketResendEnable, &enablePacketResend);
+	 pGigEConfig_->enablePacketResend = enablePacketResend;
+	 asynPrint(pasynUserSelf, ASYN_TRACE_WARNING, 
+    		"%s::%s calling GigECamera::SetGigEConfig pGigECamera=%p, pGigEConfig->enablePacketResend =%d, pGigEConfig->registerTimeoutRetries=%d, pGigEConfig->registerTimeout=%d\n", 
+    		driverName, functionName, pGigECamera_, pGigEConfig_ -> enablePacketResend, pGigEConfig_-> registerTimeoutRetries, pGigEConfig_->registerTimeout );
+	 error = pGigECamera_->SetGigEConfig(pGigEConfig_);
+    if (checkError(error, functionName, "SetGigeEConfig")) 
+        return asynError;
+	 
     // Set the binning
     getIntegerParam(PGBinningMode, &binningMode);
     asynPrint(pasynUserSelf, ASYN_TRACE_WARNING,
@@ -2552,6 +2587,24 @@ asynStatus pointGrey::getAllProperties()
     return asynSuccess;
 }
 
+asynStatus pointGrey::getGigEConfigParams()
+{
+	Error error;
+	static const char *functionName="getGigEConfigParams";
+	
+	if(pGigECamera_ == NULL) return asynError;
+	
+	error = pGigECamera_->GetGigEConfig(pGigEConfig_);
+	if (checkError(error, functionName, "GetGigEConfigStruct")) 
+   	return asynError;
+   asynPrint(pasynUserSelf, ASYN_TRACE_WARNING,
+            "%s::%s called GigECamera::GetGigEConfigParam, pGigECamera_=%p, pGigEConfig->enablePacketResend=%d, pGigEConfig->registerTimeoutRetries=%d, pGigEConfig->registerTimeout=%d\n",
+            driverName, functionName, pGigECamera_, pGigEConfig_->enablePacketResend, pGigEConfig_->registerTimeoutRetries, pGigEConfig_->registerTimeout);
+   
+    setIntegerParam(PGPacketResendEnable,pGigEConfig_->enablePacketResend);  
+    return asynSuccess;        
+}
+
 asynStatus pointGrey::getAllGigEProperties()
 {
     GigEProperty *pProperty;
@@ -2837,6 +2890,9 @@ void pointGrey::report(FILE *fp, int details)
         error = pGigECamera_->GetGigEImageBinningSettings(&binX, &binY);
         if (checkError(error, functionName, "GetGigEImageBinningSettings")) 
             return;
+        error = pGigECamera_-> GetGigEConfig(pGigEConfig_);
+        if(checkError(error, functionName, "GetGigEConfig"))
+        		return;    
         pixelFormatIndex = getPixelFormatIndex(gigESettings.pixelFormat);
         getAllGigEProperties();
         getIntegerParam(PACKET_SIZE,       PGGigEPropertyValue, &packetSize);
@@ -2848,6 +2904,7 @@ void pointGrey::report(FILE *fp, int details)
         fprintf(fp, "               Mode: %d\n",    gigEMode);
         fprintf(fp, "        Packet size: %d\n",    packetSize);
         fprintf(fp, "       Packet delay: %d\n",    packetDelay);
+        fprintf(fp, "Packet resend enable:%d\n", 	 pGigEConfig_ -> enablePacketResend);
         fprintf(fp, "          Heartbeat: %d\n",    heartBeat);
         fprintf(fp, "  Heartbeat timeout: %d\n",    heartBeatTimeout);
         fprintf(fp, "             Offset: %d %d\n", gigESettings.offsetX, gigESettings.offsetY);


### PR DESCRIPTION
Hi, Resend Packet Enable can be very useful to avoid image consistency errors in FlyCap2 GigE cameras.  I did not modified any GUIs since Marks keeps adl master copy anyways, and did my best to follow the code structure. Plz comment. Also, I wonder if there are any tests (auto or not) which could be used to make sure nothing got broken. Thanks. 